### PR TITLE
Small fix for compiler warning

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -484,7 +484,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     unsigned int i;
     uint8_t header;
     unsigned int len;
-    int expectedLength;
+    unsigned int expectedLength;
 
     if (!connected()) {
         return false;


### PR DESCRIPTION
Fix for compiler warning warning:
`PubSubClient.cpp:523:19: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]`
Issues: #799, #744, #705